### PR TITLE
fix(ncaa): remove unnecessary `must` attribute from NCAATeamCode struct feat(set): add reduceHTML function to filter selection by text fix(set): refactor cfg.MustBePresent check to use reduceHTML function chore(set): add missing import for strings package refactor(testdata): remove `must` attribute from testdata/example.go struct fix(slices): optimize cfg.MustBePresent handling by reducing HTML node selection chore(set): update setFieldValue function with error handling for unsupported types style(ncaa): improve code readability by removing redundant attribute chore(slices): remove redundant text extraction in cfg.MustBePresent check

### DIFF
--- a/examples/ncaa/ncaa.go
+++ b/examples/ncaa/ncaa.go
@@ -25,6 +25,6 @@ func ScrapeTeamCodes(
 // NCAATeamCode is a struct for a team code
 // @url:
 type NCAATeamCode struct {
-	ID   int    `json:"id"   seltabl:"ID"   hSel:"tr.grey_heading td:nth-child(1)" dSel:"tr:not(.grey_heading):not(.heading) td:nth-child(1)" cSel:"$text" must:"NCAA Codes"`
+	ID   int    `json:"id"   seltabl:"ID"   hSel:"tr.grey_heading td:nth-child(1)" dSel:"tr:not(.grey_heading):not(.heading) td:nth-child(1)" cSel:"$text"`
 	Name string `json:"name" seltabl:"Name" hSel:"tr.grey_heading td:nth-child(2)" dSel:"tr:not(.grey_heading):not(.heading) td:nth-child(2)" cSel:"$text"`
 }

--- a/set.go
+++ b/set.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 
 	"github.com/PuerkitoBio/goquery"
 )
@@ -146,4 +147,16 @@ func setFieldValue(
 	default:
 		return fmt.Errorf("unsupported type: %s", fieldType)
 	}
+}
+
+// reduceHTML removes all nodes from the selection that do not contain the
+// text.
+func reduceHTML(sel *goquery.Selection, text string) *goquery.Selection {
+	sel.Each(func(_ int, s *goquery.Selection) {
+		body := s.Text()
+		if !strings.Contains(body, text) {
+			s.Remove()
+		}
+	})
+	return sel
 }

--- a/slices.go
+++ b/slices.go
@@ -78,10 +78,7 @@ func New[T any](doc *goquery.Document) ([]T, error) {
 			results = make([]T, dataRows.Length())
 		}
 		if cfg.MustBePresent != "" {
-			txt := doc.Text()
-			if !strings.Contains(txt, cfg.MustBePresent) {
-				return nil, &ErrMissingMustBePresent{field, cfg}
-			}
+			dataRows = reduceHTML(dataRows, cfg.MustBePresent)
 		}
 		for j := 0; j < dataRows.Length(); j++ {
 			if err := SetStructField(

--- a/tools/seltabls/testdata/example.go
+++ b/tools/seltabls/testdata/example.go
@@ -2,6 +2,6 @@ package testdata
 
 // @url: https://stats.ncaa.org/game_upload/team_codes
 type TeamCode struct {
-	ID   int    `json:"id"   seltabl:"ID"   hSel:"tr.grey_heading td:nth-child(1)" dSel:"tr:not(.grey_heading):not(.heading) td:nth-child(1)" ctl:"text" must:"NCAA Codes"`
+	ID   int    `json:"id"   seltabl:"ID"   hSel:"tr.grey_heading td:nth-child(1)" dSel:"tr:not(.grey_heading):not(.heading) td:nth-child(1)" ctl:"text"`
 	Name string `json:"name" seltabl:"Name" hSel:"tr.grey_heading td:nth-child(2)" dSel:"tr:not(.grey_heading):not(.heading) td:nth-child(2)" ctl:"text"`
 }


### PR DESCRIPTION
feat(set): add reduceHTML function to filter selection by text
fix(set): refactor cfg.MustBePresent check to use reduceHTML function
chore(set): add missing import for strings package
refactor(testdata): remove `must` attribute from testdata/example.go struct
fix(slices): optimize cfg.MustBePresent handling by reducing HTML node selection
chore(set): update setFieldValue function with error handling for unsupported types
style(ncaa): improve code readability by removing redundant attribute
chore(slices): remove redundant text extraction in cfg.MustBePresent check