### PR TITLE
fix(sql): add GetHTMLByURL query to retrieve HTML by URL

### DIFF
--- a/tools/seltabls/data/master/combined/queries.sql
+++ b/tools/seltabls/data/master/combined/queries.sql
@@ -82,6 +82,15 @@ DELETE FROM
 WHERE
     id = ?;
 
+-- name: GetHTMLByURL :one
+SELECT
+    htmls.*
+FROM
+    htmls
+    JOIN urls ON urls.html_id = htmls.id
+WHERE
+    urls.value = ?;
+
 /******************************************************************************/
 
 /*

--- a/tools/seltabls/data/master/queries.sql.go
+++ b/tools/seltabls/data/master/queries.sql.go
@@ -229,6 +229,41 @@ func (q *Queries) GetFileByURI(ctx context.Context, arg GetFileByURIParams) (*Fi
 	return &i, err
 }
 
+const getHTMLByURL = `-- name: GetHTMLByURL :one
+SELECT
+    htmls.id, htmls.value, htmls.updated_at, htmls.created_at
+FROM
+    htmls
+    JOIN urls ON urls.html_id = htmls.id
+WHERE
+    urls.value = ?
+`
+
+type GetHTMLByURLParams struct {
+	Value string `db:"value" json:"value"`
+}
+
+// GetHTMLByURL
+//
+//	SELECT
+//	    htmls.id, htmls.value, htmls.updated_at, htmls.created_at
+//	FROM
+//	    htmls
+//	    JOIN urls ON urls.html_id = htmls.id
+//	WHERE
+//	    urls.value = ?
+func (q *Queries) GetHTMLByURL(ctx context.Context, arg GetHTMLByURLParams) (*Html, error) {
+	row := q.db.QueryRowContext(ctx, getHTMLByURL, arg.Value)
+	var i Html
+	err := row.Scan(
+		&i.ID,
+		&i.Value,
+		&i.UpdatedAt,
+		&i.CreatedAt,
+	)
+	return &i, err
+}
+
 const getLineByID = `-- name: GetLineByID :one
 SELECT
     id, value, number

--- a/tools/seltabls/data/master/queries/htmls.sql
+++ b/tools/seltabls/data/master/queries/htmls.sql
@@ -30,4 +30,13 @@ DELETE FROM
 WHERE
     id = ?;
 
+-- name: GetHTMLByURL :one
+SELECT
+    htmls.*
+FROM
+    htmls
+    JOIN urls ON urls.html_id = htmls.id
+WHERE
+    urls.value = ?;
+
 /******************************************************************************/

--- a/tools/seltabls/main.go
+++ b/tools/seltabls/main.go
@@ -29,12 +29,12 @@ func main() {
 // TableStruct is a test struct.
 //
 // @url: https://stats.ncaa.org/game_upload/team_codes
-// @ignore-elements: script, style, link, img, footer, header
+// @ignore: script, style, link, img, footer, header
 // @occurrences: 1
 type TableStruct struct {
-	A string `hSel:"html>body>div.footer>div"              dSel:"html>body>div.footer>div>span>a[href]" ctl:"$text"`
+	A string `hSel:"html>body>div"              dSel:"html>body>div.footer>div>span>a[href]" ctl:"$text"`
 	B string `hSel:"html>body>div.footer>div>span>a[href]" dSel:"html>body>div>table>tbody>tr.row_odd"  ctl:"$text"`
 	C string `hSel:"html>body>div>table>tbody>tr.row_even" dSel:"html>body>div"                         ctl:"$text"`
 	D string `hSel:"html>body>div.footer>div>span>a[href]" dSel:"html>body>div.footer>div>span>a[href]" ctl:"$text"`
-	E string `hSel:"html>body>div.footer>div>span>a[href]" dSel:"html>body>div.footer>div>span>a[href]" ctl:"$text"`
+	E string `hSel:"" dSel:"html>body>div.footer>div>span>a[href]" ctl:"$text"`
 }

--- a/tools/seltabls/pkg/analysis/open.go
+++ b/tools/seltabls/pkg/analysis/open.go
@@ -58,17 +58,20 @@ func OpenDocument(
 				} else {
 					occur = 2
 				}
-				sels, err := parsers.GetSelectors(
-					ctx,
-					db,
-					url,
-					data.IgnoreElements[i],
-					occur,
-				)
-				if err != nil {
-					return err
+				var sels []master.Selector
+				for _, ele := range data.IgnoreElements {
+					sels, err = parsers.GetSelectors(
+						ctx,
+						db,
+						url,
+						ele,
+						occur,
+					)
+					if err != nil {
+						return err
+					}
+					selectors.Set(req.Params.TextDocument.URI, append(sels, sels...))
 				}
-				selectors.Set(req.Params.TextDocument.URI, sels)
 				return nil
 			})
 		}

--- a/tools/seltabls/pkg/lsp/responses.go
+++ b/tools/seltabls/pkg/lsp/responses.go
@@ -102,7 +102,7 @@ func NewInitializeResponse(
 						CompletionProvider: &protocol.CompletionOptions{
 							TriggerCharacters: []string{":"},
 						},
-						HoverProvider:                    false,
+						HoverProvider:                    true,
 						SignatureHelpProvider:            &protocol.SignatureHelpOptions{},
 						DeclarationProvider:              false,
 						DefinitionProvider:               false,

--- a/tools/seltabls/pkg/server/handle.go
+++ b/tools/seltabls/pkg/server/handle.go
@@ -95,6 +95,7 @@ func HandleMessage(
 			return analysis.NewHoverResponse(
 				ctx,
 				request,
+				db,
 				documents,
 				urls,
 			)


### PR DESCRIPTION
feat(api): implement GetHTMLByURL function in queries.sql.go

refactor(data): include GetHTMLByURL query in htmls.sql

fix(comments): revise struct tag comments in main.go for clarity

docs(structure): update docstrings for TableStruct in main.go

refactor(hover): integrate GetHTMLByURL in NewHoverResponse function

fix(hover): use concurrency to handle multiple struct nodes in GetSelectorHover

feat(init): enable hover provider in language server response

refactor(open): iterate ignore elements in OpenDocument for selector retrieval

fix(deps): add missing imports and update package references in hover.go
