### PR TITLE
devit

### DIFF
--- a/slices.go
+++ b/slices.go
@@ -176,12 +176,8 @@ func New[T any](doc *goquery.Document) ([]T, error) {
 //		}
 //	}
 func NewFromString[T any](htmlInput string) ([]T, error) {
-	reader := strings.NewReader(
-		htmlInput,
-	)
-	doc, err := goquery.NewDocumentFromReader(
-		reader,
-	)
+	reader := strings.NewReader(htmlInput)
+	doc, err := goquery.NewDocumentFromReader(reader)
 	if err != nil {
 		return nil,
 			fmt.Errorf(
@@ -303,9 +299,7 @@ func NewFromURL[T any](url string) ([]T, error) {
 		return nil, fmt.Errorf("failed to read body: %w", err)
 	}
 	doc, err := goquery.NewDocumentFromReader(
-		strings.NewReader(
-			string(body),
-		),
+		strings.NewReader(string(body)),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse html: %w", err)
@@ -365,9 +359,7 @@ func NewFromURL[T any](url string) ([]T, error) {
 //	}
 func NewFromBytes[T any](b []byte) ([]T, error) {
 	doc, err := goquery.NewDocumentFromReader(
-		strings.NewReader(
-			string(b),
-		),
+		strings.NewReader(string(b)),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse html: %w", err)
@@ -478,4 +470,196 @@ func NewFromBytesCh[T any](b []byte, ch chan T) error {
 		return fmt.Errorf("failed to parse html: %w", err)
 	}
 	return NewCh(doc, ch)
+}
+
+// NewFromURLCh parses a given URL's html into a slice of structs adhering to the
+// given generic type.
+//
+// The URL must be a valid html page with a single table.
+//
+// The passed in generic type must be a struct with valid selectors for the
+// table and data (hSel, dSel, cSel).
+//
+// The selectors responsibilities:
+//
+//   - header selector (hSel): used to find the header row and column for the
+//     field in the given struct.
+//   - data selector (dSel): used to find the data column for the field in the
+//     given struct.
+//   - query selector (qSel): used to query for the inner text or attribute of
+//     the cell.
+//   - control selector (cSel): used to control what to query for the inner
+//     text or attribute of the cell.
+//
+// Example:
+//
+//	package main
+//
+//	import (
+//		"fmt"
+//		"github.com/conneroisu/seltabl"
+//	)
+//
+//	type FixtureStruct struct {
+//	        A string `json:"a" hSel:"tr:nth-child(1)" dSel:"table tr:not(:first-child) td:nth-child(1)" cSel:"$text"`
+//	        B string `json:"b" hSel:"tr:nth-child(1)" dSel:"table tr:not(:first-child) td:nth-child(2)" cSel:"$text"`
+//	}
+//
+//	func main() {
+//		p, err := seltabl.NewFromURLCh[TableStruct]("https://github.com/conneroisu/seltabl/blob/main/testdata/ab_num_table.html", ch)
+//		if err != nil {
+//			panic(err)
+//		}
+//		for _, pp := range p {
+//			fmt.Printf("pp %+v\n", pp)
+//		}
+//	}
+func NewFromURLCh[T any](url string, ch chan T) error {
+	client := &http.Client{}
+	resp, err := client.Get(url)
+	if err != nil {
+		return fmt.Errorf("failed to get url: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read body: %w", err)
+	}
+	doc, err := goquery.NewDocumentFromReader(
+		strings.NewReader(
+			string(body),
+		),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to parse html: %w", err)
+	}
+	return NewCh(doc, ch)
+}
+
+// NewChFn parses a reader into a channel of structs.
+//
+// It also applies a function to each struct before adding it to the channel.
+func NewChFn[
+	T any,
+	F func(T) bool,
+](
+	doc *goquery.Document,
+	ch chan T,
+	fn F,
+) error {
+	dType := reflect.TypeOf((*T)(nil)).Elem()
+	if dType.Kind() != reflect.Struct && dType.Kind() != reflect.Ptr {
+		return fmt.Errorf("expected struct, got %s", dType.Kind())
+	}
+	results := make([]T, 0)
+	var cfg *SelectorConfig
+	for i := 0; i < dType.NumField(); i++ {
+		cfg = NewSelectorConfig(dType.Field(i).Tag)
+		if cfg.DataSelector == "" {
+			return ErrSelectorNotFound{
+				Typ:   dType,
+				Field: dType.Field(i),
+				Cfg:   cfg,
+			}
+		}
+		dataRows := doc.Find(cfg.DataSelector)
+		if dataRows.Length() <= 0 {
+			return ErrNoDataFound{
+				Typ:   dType,
+				Field: dType.Field(i),
+				Cfg:   cfg,
+			}
+		}
+		if cfg.HeadSelector != "" && cfg.HeadSelector != "-" {
+			_ = dataRows.RemoveFiltered(cfg.HeadSelector)
+		}
+		if len(results) < dataRows.Length() {
+			results = make([]T, dataRows.Length())
+		}
+		if dataRows.Length() == 0 {
+			return ErrNoDataFound{
+				Typ:   dType,
+				Field: dType.Field(i),
+				Cfg:   cfg,
+			}
+		}
+		for j := 0; j < dataRows.Length(); j++ {
+			err := SetStructField(
+				&results[j],
+				dType.Field(i), // name of the field to set
+				dataRows.Eq(j), // goquery selection for cell
+				&selector{
+					control: cfg.ControlTag,
+					query:   cfg.QuerySelector,
+				}, // selector for the inner cell
+			)
+			if err != nil {
+				return fmt.Errorf(
+					"failed to set field %s: %s",
+					dType.Field(i).Name,
+					err,
+				)
+			}
+			if fn(results[j]) {
+				ch <- results[j]
+			}
+		}
+	}
+	return nil
+}
+
+// NewFromReaderChFn parses a reader into a channel of structs.
+// It also applies a function to each struct before adding it to the channel.
+func NewFromReaderChFn[
+	T any,
+	F func(T) bool,
+](
+	r io.Reader,
+	ch chan T,
+	fn F,
+) error {
+	doc, err := goquery.NewDocumentFromReader(r)
+	if err != nil {
+		return fmt.Errorf("failed to parse html: %w", err)
+	}
+	return NewChFn(doc, ch, fn)
+}
+
+// NewFromStringChFn parses a string into a channel of structs.
+// It also applies a function to each struct before adding it to the channel.
+func NewFromStringChFn[
+	T any,
+	F func(T) bool,
+](
+	htmlInput string,
+	ch chan T,
+	fn F,
+) error {
+	reader := strings.NewReader(htmlInput)
+	doc, err := goquery.NewDocumentFromReader(
+		reader,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to parse html: %w", err)
+	}
+	return NewChFn(doc, ch, fn)
+}
+
+// NewFromBytesChFn parses a byte slice into a channel of structs.
+// It also applies a function to each struct before adding it to the channel.
+func NewFromBytesChFn[
+	T any,
+	F func(T) bool,
+](
+	b []byte,
+	ch chan T,
+	fn F,
+) error {
+	doc, err := goquery.NewDocumentFromReader(
+		strings.NewReader(string(b)),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to parse html: %w", err)
+	}
+	return NewChFn(doc, ch, fn)
 }


### PR DESCRIPTION
- **feat(set): update SetStructField to utilize reflect.StructField test(set): refactor tests to use reflect.StructField for field referencing refactor(set): remove duplicated test cases in TestSetStructField feat(slices): introduce baseModelType for improved reflect.Type usage feat(slices): add NewCh function to parse goquery doc and deliver to channel feat(slices): add NewFromReaderCh function to parse reader into slice of structs feat(slices): add NewFromStringCh function to parse string into slice of structs feat(slices): add NewFromBytesCh function to parse byte slice into slice of structs refactor(tests): remove obsolete BenchSetStructField benchmark tests docs(slices): add documentation for new functions utilizing channels**
- **fix(tests): remove t.Parallel() in TestSetStructField**
- **fix(dependencies): remove unused OpenTelemetry libraries chore(deps): update go.mod to tidy dependencies refactor(modules): clean up go.mod by removing redundant imports perf(dependencies): eliminate unnecessary OpenTelemetry dependencies fix(dependencies): remove obsolete go-logr dependency entries chore(modules): update go.sum after dependency cleanup in go.mod refactor: streamline module imports by removing unused packages chore(deps): tidy up go.sum to reflect recent changes in go.mod style(dependencies): clean up go.mod by removing extraneous dependencies**
- **add ch funcs**
